### PR TITLE
Remove stray semicolon in condition

### DIFF
--- a/app.R
+++ b/app.R
@@ -27,7 +27,7 @@ ui <- function(request) {
       analyticsUI("app", github = github)
     ),
     profile = conditionalPanel(
-      condition = "rstudio.Photos.indexOf(output.view) !== -1;",
+      condition = "rstudio.Photos.indexOf(output.view) !== -1",
       profileUI("profile")
     )
   )


### PR DESCRIPTION
Conditions are expressions, not statements, so they don't get semicolons.